### PR TITLE
Remove useless scripts.

### DIFF
--- a/_gencontinuous.bat
+++ b/_gencontinuous.bat
@@ -1,2 +1,0 @@
-@ECHO OFF
-CALL ./_genonce.bat -watch

--- a/_gencontinuous.sh
+++ b/_gencontinuous.sh
@@ -1,2 +1,0 @@
-#!/bin/bash
-./_genonce.sh -watch


### PR DESCRIPTION
Support for the -watch option was deprecated in June, 2023, rendering the _gencontinuous scripts useless.